### PR TITLE
OQ-6: wire 'Re-optimize' on Fleet Scheduling tile to ottoq-orchestrat…

### DIFF
--- a/src/components/fleet/fleet-scheduling-tile.tsx
+++ b/src/components/fleet/fleet-scheduling-tile.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import { useScheduleIntelligence } from "@/hooks/use-otto-q-strategic";
+import { useScheduleIntelligence, useReoptimizeDepot } from "@/hooks/use-otto-q-strategic";
 import { Card } from "@/components/ui/card";
+import { toast } from "sonner";
 import { SchedulingTimeline } from "./scheduling-timeline";
 import {
   Brain,
@@ -11,6 +12,8 @@ import {
   DollarSign,
   Activity,
   TrendingUp,
+  Sparkles,
+  Loader2,
 } from "lucide-react";
 import type {
   PendingOptimization,
@@ -22,6 +25,7 @@ export function FleetSchedulingTile() {
   const [horizon, setHorizon] = useState<"12h" | "24h" | "48h">("24h");
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
   const { data, isLoading } = useScheduleIntelligence(horizon);
+  const reopt = useReoptimizeDepot();
 
   if (isLoading || !data) {
     return (
@@ -67,21 +71,44 @@ export function FleetSchedulingTile() {
           </div>
         </div>
 
-        {/* Horizon selector */}
-        <div className="flex items-center gap-1 rounded-md border border-border/40 bg-muted/20 p-0.5 self-start">
-          {(["12h", "24h", "48h"] as const).map((h) => (
-            <button
-              key={h}
-              onClick={() => setHorizon(h)}
-              className={`px-3 py-1 text-xs font-medium rounded transition ${
-                horizon === h
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:bg-muted"
-              }`}
-            >
-              {h}
-            </button>
-          ))}
+        {/* Actions */}
+        <div className="flex items-center gap-2 self-start">
+          <button
+            onClick={() =>
+              reopt.mutate(undefined, {
+                onSuccess: (r) =>
+                  toast.success("Depot re-optimized", {
+                    description: `${r?.summary?.vehicles_planned ?? 0} vehicles · ${r?.summary?.charge_assigned ?? 0} charge (${r?.summary?.charge_source ?? "-"}) · ${r?.summary?.tasks_awaiting_resource ?? 0} awaiting`,
+                  }),
+                onError: (e) => toast.error("Re-optimize failed", { description: e.message }),
+              })
+            }
+            disabled={reopt.isPending}
+            title="Run OTTO-Q depot-wide re-optimization (cuOpt + energy cap + safety shield)"
+            className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium rounded-md border border-primary/30 bg-primary/10 text-primary hover:bg-primary/20 transition disabled:opacity-50"
+          >
+            {reopt.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Sparkles className="h-3.5 w-3.5" />
+            )}
+            Re-optimize
+          </button>
+          <div className="flex items-center gap-1 rounded-md border border-border/40 bg-muted/20 p-0.5">
+            {(["12h", "24h", "48h"] as const).map((h) => (
+              <button
+                key={h}
+                onClick={() => setHorizon(h)}
+                className={`px-3 py-1 text-xs font-medium rounded transition ${
+                  horizon === h
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted"
+                }`}
+              >
+                {h}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/src/hooks/use-otto-q-strategic.ts
+++ b/src/hooks/use-otto-q-strategic.ts
@@ -1,6 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   ottoQFetch,
+  ottoqInvoke,
   FleetSummary,
   AIFleetSummary,
   EnergyHistory,
@@ -47,5 +48,33 @@ export function useEnergyHistory(
     queryKey: ["otto-q", "energy-history", range, depotId || "all"],
     queryFn: () => ottoQFetch<EnergyHistory>(`/energy/history?${qs}`),
     staleTime: 5 * 60 * 1000,
+  });
+}
+
+export interface OrchestrateTickResult {
+  depot?: string;
+  energy?: { tariff?: string; max_concurrent_dcfc?: number; billing_peak_kw?: number };
+  summary?: {
+    vehicles_planned?: number;
+    charge_assigned?: number;
+    charge_source?: string;
+    tasks_awaiting_resource?: number;
+  };
+}
+
+// Triggers OTTO-Q's depot-wide re-optimizer (cuOpt assignment + energy cap + 52-rule shield).
+// Defaults to the primary depot if no depotId is given.
+export function useReoptimizeDepot(depotId?: string) {
+  const qc = useQueryClient();
+  return useMutation<OrchestrateTickResult, Error, void>({
+    mutationFn: () =>
+      ottoqInvoke<OrchestrateTickResult>("ottoq-orchestrate-tick", {
+        depot_id: depotId,
+        submit: true,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["otto-q", "schedule-intelligence"] });
+      qc.invalidateQueries({ queryKey: ["otto-q", "fleet-summary"] });
+    },
   });
 }

--- a/src/lib/otto-q-api.ts
+++ b/src/lib/otto-q-api.ts
@@ -30,6 +30,25 @@ export async function ottoQFetch<T = unknown>(
   return (json?.data ?? json) as T;
 }
 
+// Direct invoke of an OTTO-Q edge FUNCTION on otto-q-core (not the otto-q-api REST gateway).
+// Used for the frontier functions (orchestrate-tick, amend, cleaning-cadence, …) that aren't
+// exposed under /api/v1. Reuses the otto-q-core base URL + anon key above (correct project).
+const OTTOQ_FN_BASE = OTTOQ_BASE.replace(/\/otto-q-api\/api\/v1\/?$/, "");
+
+export async function ottoqInvoke<T = unknown>(fn: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${OTTOQ_FN_BASE}/${fn}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${OTTOQ_KEY}`,
+      apikey: OTTOQ_KEY,
+    },
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!res.ok) throw new Error(`OTTO-Q ${fn} ${res.status}: ${await res.text()}`);
+  return (await res.json()) as T;
+}
+
 // --- Type definitions ---
 
 export interface FleetSummaryDepot {


### PR DESCRIPTION
…e-tick

Adds a depot-wide Re-optimize action that calls OTTO-Q's real orchestrate-tick (cuOpt assignment + energy cap + 52-rule shield) on otto-q-core and toasts the result. New ottoqInvoke() helper in otto-q-api.ts (direct edge-function calls on otto-q-core, reusing the existing otto-q-core base+key) + useReoptimizeDepot hook.