### PR TITLE
Orchestra: live Fleet Comms feed (vehicle ↔ OTTO-Q ↔ teleop)

### DIFF
--- a/src/components/FleetCommand/OttoQIntelligence/FleetComms.tsx
+++ b/src/components/FleetCommand/OttoQIntelligence/FleetComms.tsx
@@ -1,0 +1,148 @@
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Radio,
+  Send,
+  CheckCircle2,
+  ShieldQuestion,
+  ShieldCheck,
+  ShieldX,
+  ArrowUp,
+  ArrowDown,
+  Gauge,
+  Activity,
+} from "lucide-react";
+import {
+  useFleetComms,
+  type CommsMessage,
+} from "@/hooks/use-fleet-comms";
+
+// Pillar 2 — live fleet comms bus. Shows the real vehicle <-> OTTO-Q <-> teleoperator traffic,
+// built to the protocols OEMs actually run (MQTT / SAE J2735 BSM / ISO 20078 / SAE J3016).
+
+const AMBER = "hsl(45, 93%, 47%)";
+const GREEN = "hsl(142, 76%, 36%)";
+const VIOLET = "hsl(259, 70%, 62%)";
+
+type Style = { label: string; color: string; icon: typeof Radio };
+
+const styleFor = (m: CommsMessage): Style => {
+  const cmd = (m.payload?.["command"] as string | undefined) ?? "";
+  switch (m.msg_type) {
+    case "telemetry":
+      return { label: "BSM telemetry", color: "hsl(var(--primary))", icon: Radio };
+    case "command":
+      return { label: `${cmd || "command"}`, color: AMBER, icon: Send };
+    case "ack":
+      return { label: `${cmd || "ack"} · ack`, color: GREEN, icon: CheckCircle2 };
+    case "assist_request":
+      return { label: "teleop review", color: VIOLET, icon: ShieldQuestion };
+    case "assist_response":
+      return m.status === "deny"
+        ? { label: "teleop · deny", color: "hsl(var(--destructive))", icon: ShieldX }
+        : { label: "teleop · approve", color: GREEN, icon: ShieldCheck };
+    default:
+      return { label: m.msg_type, color: "hsl(var(--muted-foreground))", icon: Activity };
+  }
+};
+
+const vehTag = (id: string | null) => (id ? id.slice(0, 8) : "—");
+const clockOf = (t: string | null) =>
+  t ? new Date(t).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" }) : "—";
+
+export const FleetComms = () => {
+  const { data, isLoading } = useFleetComms(80);
+  const messages = data?.messages ?? [];
+  const s = data?.summary;
+
+  const stats = [
+    { label: "BSM Telemetry", value: s?.telemetry ?? 0, sub: "uplink", icon: Radio, color: "hsl(var(--primary))" },
+    { label: "Commands", value: s?.commands ?? 0, sub: "downlink", icon: Send, color: AMBER },
+    { label: "Teleop Reviews", value: s?.teleopReviews ?? 0, sub: `${s?.teleopApproved ?? 0} approved · ${s?.teleopDenied ?? 0} denied`, icon: ShieldCheck, color: VIOLET },
+    { label: "Avg Latency", value: s?.avgLatencyMs != null ? `${s.avgLatencyMs} ms` : "—", sub: "round-trip", icon: Gauge, color: GREEN },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div>
+          <h2 className="text-xl font-bold">Fleet Comms</h2>
+          <p className="text-[11px] text-muted-foreground">
+            MQTT transport · SAE&nbsp;J2735 BSM telemetry · ISO&nbsp;20078 envelope · SAE&nbsp;J3016 teleop
+          </p>
+        </div>
+        <Badge variant="outline" className="text-[10px]">live · vehicle ↔ OTTO-Q ↔ teleop</Badge>
+      </div>
+
+      {/* Summary strip — derived from the live bus */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {stats.map((st) => (
+          <Card key={st.label} className="glass-card p-3">
+            <div className="flex items-center gap-2">
+              <div className="p-1.5 rounded-lg" style={{ backgroundColor: `${st.color}20` }}>
+                <st.icon className="h-4 w-4" style={{ color: st.color }} />
+              </div>
+              <div className="min-w-0">
+                <p className="text-[10px] uppercase tracking-wider text-muted-foreground truncate">{st.label}</p>
+                <p className="text-sm font-bold">{st.value}</p>
+                <p className="text-[9px] text-muted-foreground truncate">{st.sub}</p>
+              </div>
+            </div>
+          </Card>
+        ))}
+      </div>
+
+      {/* The bus — most recent traffic */}
+      <Card className="glass-card">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <p className="text-sm font-semibold">Message Bus</p>
+          <span className="text-[10px] text-muted-foreground">{messages.length} recent</span>
+        </div>
+
+        {messages.length === 0 ? (
+          <div className="flex items-center justify-center text-center px-6 py-16">
+            <p className="text-xs text-muted-foreground max-w-md">
+              {isLoading
+                ? "Connecting to the fleet comms bus…"
+                : "No fleet comms in the recent window. The bus fills as OTTO-Q orchestrates a live operation — every deployed vehicle streams BSM telemetry, and OTTO-Q's dispatch/recall commands plus teleoperator confirmations flow through here in real time."}
+            </p>
+          </div>
+        ) : (
+          <div className="max-h-[460px] overflow-y-auto divide-y divide-border/60">
+            {messages.map((m) => {
+              const st = styleFor(m);
+              const up = m.direction === "uplink";
+              return (
+                <div key={m.msg_id} className="flex items-center gap-3 px-4 py-2 hover:bg-muted/20">
+                  <div className="p-1.5 rounded-lg shrink-0" style={{ backgroundColor: `${st.color}20` }}>
+                    <st.icon className="h-3.5 w-3.5" style={{ color: st.color }} />
+                  </div>
+
+                  <div className="flex items-center gap-1 shrink-0 w-[78px]" title={up ? "vehicle → OTTO-Q" : "OTTO-Q → vehicle"}>
+                    {up ? <ArrowUp className="h-3 w-3 text-muted-foreground" /> : <ArrowDown className="h-3 w-3 text-muted-foreground" />}
+                    <span className="text-[10px] text-muted-foreground">{up ? "veh → Q" : "Q → veh"}</span>
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    <p className="text-xs font-medium truncate" style={{ color: st.color }}>{st.label}</p>
+                    <p className="text-[10px] text-muted-foreground font-mono truncate">{m.topic ?? "—"}</p>
+                  </div>
+
+                  <div className="hidden sm:flex flex-col items-end shrink-0">
+                    <span className="text-[10px] text-muted-foreground">veh {vehTag(m.vehicle_id)}</span>
+                    <div className="flex items-center gap-1">
+                      {m.qos != null && <Badge variant="outline" className="text-[8px] px-1 py-0">QoS {m.qos}</Badge>}
+                      {m.latency_ms != null && <span className="text-[9px] text-muted-foreground">{m.latency_ms}ms</span>}
+                    </div>
+                  </div>
+
+                  <span className="text-[10px] text-muted-foreground font-mono shrink-0 w-[64px] text-right">{clockOf(m.sim_clock_at)}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+};

--- a/src/components/FleetCommand/OttoQIntelligence/index.ts
+++ b/src/components/FleetCommand/OttoQIntelligence/index.ts
@@ -2,4 +2,5 @@ export { OperationsOverview } from "./OperationsOverview";
 export { ThroughputAnalytics } from "./ThroughputAnalytics";
 export { EnergyDashboard } from "./EnergyDashboard";
 export { PredictionPerformance } from "./PredictionPerformance";
+export { FleetComms } from "./FleetComms";
 export { AlertsConfigPanel } from "./AlertsConfigPanel";

--- a/src/hooks/use-fleet-comms.ts
+++ b/src/hooks/use-fleet-comms.ts
@@ -1,0 +1,80 @@
+import { useQuery } from "@tanstack/react-query";
+import { ottoqTable } from "@/lib/otto-q-api";
+
+// Live fleet comms bus on otto-q-core (Pillar 2). Reads ottoq_comms_messages directly via
+// PostgREST — the vehicle <-> OTTO-Q <-> teleoperator traffic that the twin emits each tick.
+// Built to real connected-vehicle protocols so an OEM sees their own parameters, not a toy:
+//   transport = MQTT · telemetry = SAE J2735 BSM · envelope = ISO 20078 · teleop = SAE J3016.
+// Empty/idle when no run is live — same honest pattern as the energy series.
+
+export type CommsDirection = "uplink" | "downlink";
+export type CommsMsgType =
+  | "telemetry"
+  | "command"
+  | "ack"
+  | "assist_request"
+  | "assist_response";
+
+export interface CommsMessage {
+  msg_id: string;
+  vehicle_id: string | null;
+  correlation_id: string | null;
+  direction: CommsDirection;
+  topic: string | null;
+  msg_type: CommsMsgType;
+  qos: number | null;
+  payload: Record<string, unknown> | null;
+  status: string | null;
+  latency_ms: number | null;
+  sim_clock_at: string | null;
+}
+
+export interface CommsSummary {
+  total: number;
+  telemetry: number;
+  commands: number;
+  teleopReviews: number;
+  teleopApproved: number;
+  teleopDenied: number;
+  avgLatencyMs: number | null;
+  lastClock: string | null;
+}
+
+const SELECT =
+  "select=msg_id,vehicle_id,correlation_id,direction,topic,msg_type,qos,payload,status,latency_ms,sim_clock_at";
+
+export function useFleetComms(limit = 80) {
+  return useQuery({
+    queryKey: ["fleet-comms", limit],
+    refetchInterval: 8000,
+    queryFn: async () => {
+      const rows = await ottoqTable<CommsMessage[]>(
+        "ottoq_comms_messages",
+        `${SELECT}&order=sim_clock_at.desc,msg_id.desc&limit=${limit}`
+      );
+      const list = rows ?? [];
+
+      const lat = list
+        .map((m) => m.latency_ms)
+        .filter((v): v is number => v != null);
+      const summary: CommsSummary = {
+        total: list.length,
+        telemetry: list.filter((m) => m.msg_type === "telemetry").length,
+        commands: list.filter((m) => m.msg_type === "command").length,
+        teleopReviews: list.filter((m) => m.msg_type === "assist_request").length,
+        teleopApproved: list.filter(
+          (m) => m.msg_type === "assist_response" && m.status === "approve"
+        ).length,
+        teleopDenied: list.filter(
+          (m) => m.msg_type === "assist_response" && m.status === "deny"
+        ).length,
+        avgLatencyMs: lat.length
+          ? Math.round(lat.reduce((a, b) => a + b, 0) / lat.length)
+          : null,
+        lastClock: list[0]?.sim_clock_at ?? null,
+      };
+
+      return { messages: list, summary };
+    },
+  });
+}

--- a/src/pages/FleetCommandOttoQ.tsx
+++ b/src/pages/FleetCommandOttoQ.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AppHeader } from "@/components/shared/AppHeader";
-import { OperationsOverview, ThroughputAnalytics, EnergyDashboard, PredictionPerformance, AlertsConfigPanel } from "@/components/FleetCommand/OttoQIntelligence";
+import { OperationsOverview, ThroughputAnalytics, EnergyDashboard, PredictionPerformance, FleetComms, AlertsConfigPanel } from "@/components/FleetCommand/OttoQIntelligence";
 import DepotFloorPlan from "@/components/OttoQ/DepotMap/DepotFloorPlan";
 import QueueManager from "@/components/OttoQ/QueueManager";
 import { AVPipelineView } from "@/components/OttoQ/AVCommand";
 import { useAVOrchestrator } from "@/hooks/useAVOrchestrator";
-import { Activity, BarChart3, Zap, Target, Map, Bot, ListOrdered, Settings } from "lucide-react";
+import { Activity, BarChart3, Zap, Target, Map, Bot, ListOrdered, Radio, Settings } from "lucide-react";
 import type { City } from "@/components/CitySearchBar";
 
 const defaultCity: City = { name: "Nashville", coordinates: [-86.7816, 36.1627], country: "USA" };
@@ -18,6 +18,7 @@ const tabs = [
   { value: "predictions", label: "Predictions", icon: Target },
   { value: "depot-map", label: "Depot Map", icon: Map },
   { value: "av-command", label: "AV Command", icon: Bot },
+  { value: "comms", label: "Comms", icon: Radio },
   { value: "queue", label: "Queue", icon: ListOrdered },
   { value: "settings", label: "Settings", icon: Settings },
 ] as const;
@@ -52,6 +53,7 @@ const FleetCommandOttoQ = () => {
           <TabsContent value="predictions" className="animate-fade-in-up"><PredictionPerformance /></TabsContent>
           <TabsContent value="depot-map" className="animate-fade-in-up"><DepotFloorPlan depotId="demo" /></TabsContent>
           <TabsContent value="av-command" className="animate-fade-in-up"><AVPipelineView pipelines={av.pipelines} /></TabsContent>
+          <TabsContent value="comms" className="animate-fade-in-up"><FleetComms /></TabsContent>
           <TabsContent value="queue" className="animate-fade-in-up"><QueueManager /></TabsContent>
           <TabsContent value="settings" className="animate-fade-in-up"><AlertsConfigPanel /></TabsContent>
         </Tabs>


### PR DESCRIPTION
## Live Fleet Comms feed — Pillar 2

Surfaces the OTTO-Q comms bus (`ottoq_comms_messages` on otto-q-core) as a new **Comms** tab in Fleet Command — the live **vehicle ↔ OTTO-Q ↔ teleoperator** traffic the twin emits every tick, built to the protocols OEMs actually run so it reads as real, not a toy:

- **MQTT** transport (topics + QoS) · **SAE J2735 BSM** telemetry · **ISO 20078** envelope · **SAE J3016** teleop.

### What renders
- Protocol header + summary strip: BSM telemetry (uplink), commands (downlink), teleop reviews (approved/denied), avg round-trip latency.
- Message bus list: direction arrows (veh→Q / Q→veh), color-coded message types (telemetry / command / ack / teleop request / approve·deny), full MQTT topic, QoS badge, latency, timestamp.
- Honest empty/idle state when no run is live — same pattern as the energy series.

### Data path
`use-fleet-comms.ts` reads the recent bus via PostgREST (8s refetch) and derives the summary client-side. No mocks. The bus fills automatically during any live run via the new per-tick `ottoq_comms_advance` sweep wired into `ottoq_sim_advance_tick`.

Verified: `tsc --noEmit` clean, `vite build` clean, rendered against a live demo exchange on otto-q-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
